### PR TITLE
Adds SSL support

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -9,6 +9,10 @@ server {
 
 server {
   listen 80;
+  listen 443 ssl;
+
+  ssl_certificate /etc/nginx/ssl/server.crt;
+  ssl_certificate_key /etc/nginx/ssl/server.key;
 
   server_name blog.groupbuddies.com;
 


### PR DESCRIPTION
I've created a self-signed SSL certificate in the server. This will, in the
future, be used by HQ to allow us to safely communicate with it
(needed by OAuth).

Until I migrate HQ to that server, I might as well add the option to access
other apps via SSL as well. If nothing else, it allows me to make sure it's
working properly

The certificate is a wildcard one, set for *.groupbuddies.com. So any apps we
deploy to that server under that domain should be good candidates for this.