### PR TITLE
Trying to fix a memory leak

### DIFF
--- a/app/controllers/archives_controller.rb
+++ b/app/controllers/archives_controller.rb
@@ -4,7 +4,7 @@ class ArchivesController < ApplicationController
   decorates_assigned :posts
 
   def show
-    @posts = Post.all_published
+    @posts = Post.published.recent
     filter_by_category
     filter_by_author
     @archive = Facades::Archive.new(@posts.decorate)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,18 +1,16 @@
 class PostsController < ApplicationController
-  POSTS_LIMIT = 5
-
   decorates_assigned :category, :posts, :post
 
   def index
-    @posts = Post.all_published.limit(POSTS_LIMIT)
+    @posts = Post.published.recent
   end
 
   def feed
     if params[:category]
       @category = Category.from_param(params[:category])
-      @posts = @posts.by_category(@category)
+      @posts = @posts.by_category(@category).recent
     else
-      @posts = Post.all_published
+      @posts = Post.published.recent
     end
 
     respond_to do |format|

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -2,7 +2,9 @@ class Ability
   include CanCan::Ability
 
   def initialize(user)
-    can :read, Post.all_published
+    can :read, Post do |post|
+      post.published?
+    end
 
     admin_abilities if user
   end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,4 +1,6 @@
 class Post < ActiveRecord::Base
+  POSTS_LIMIT = 5
+
   default_scope  { order('published_at DESC') }
 
   belongs_to :author, class_name: 'User'
@@ -10,16 +12,20 @@ class Post < ActiveRecord::Base
 
   delegate :name, to: :author, prefix: true
 
-  def self.all_published
+  def self.published
     where('published_at IS NOT NULL')
   end
 
+  def self.recent
+    limit(POSTS_LIMIT)
+  end
+
   def self.by_category(category)
-    all_published.where(category_id: category)
+    published.where(category_id: category)
   end
 
   def self.by_author(author)
-    all_published.where(author_id: author)
+    published.where(author_id: author)
   end
 
   def self.visible_by(author)

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
 RSpec.describe Post, type: :model do
-  context '.all_published' do
+  context '.published' do
     it 'returns only posts that are published' do
       create_list(:post, 2)
       published_posts   = create_list(:published_post, 2)
 
-      Post.all_published.should match_array(published_posts)
+      Post.published.should match_array(published_posts)
     end
   end
 


### PR DESCRIPTION
Our feeds endpoint is currently fetching all posts. This limits the number,
just like we already do at the index page

This is a possible fix to the memory issue our blog currently has.